### PR TITLE
docs: add 7ya.io rest-express management baseline

### DIFF
--- a/docs/7ya-io-operating-plan.md
+++ b/docs/7ya-io-operating-plan.md
@@ -212,3 +212,33 @@ Dashboard rule: if any core KPI degrades for two consecutive weeks, trigger a fo
 - **Daily:** short blocker-driven standup.
 
 This blueprint should be treated as a living operating system: update monthly based on KPI movement, customer feedback, and regulatory constraints.
+
+
+## 11) 7ya.io Node/Express Runtime Management Baseline
+
+When operating the `rest-express` deployment, standardize around the following release workflow:
+
+- `npm run check` before every merge to enforce TypeScript correctness.
+- `npm run build` in CI to produce the deployable bundle (`dist/index.cjs`).
+- `npm run start` only in production environments with `NODE_ENV=production`.
+- `npm run db:push` only from controlled release pipelines (never ad-hoc from local machines).
+
+### 11.1 Service boundaries
+
+- Keep authentication/session dependencies (`passport`, `passport-local`, `express-session`, `connect-pg-simple`) in the API tier only.
+- Keep real-time dependencies (`socket.io`, `ws`) isolated behind explicit feature flags.
+- Keep outbound communications (`@azure/communication-email`, `resend`, `twilio`, `stripe`) behind provider adapters to avoid vendor lock-in.
+
+### 11.2 Dependency governance
+
+- Pin TypeScript major/minor versions for predictable builds (`typescript@5.6.x` baseline).
+- Review high-risk libraries monthly: auth, payments, database, and file/image processing (`sharp`).
+- Track OpenAI SDK upgrades in a dedicated changelog stream before promotion to production.
+- Require lockfile updates and a short risk note for any dependency upgrade touching security-critical paths.
+
+### 11.3 Production controls
+
+- Enforce staged rollout: development -> staging -> production with the same build artifact.
+- Add health probes for HTTP, database connectivity, and queue/websocket subsystems.
+- Record structured audit logs for auth events, billing events, and admin actions.
+- Maintain incident runbooks for degraded dependencies (Stripe, Twilio, email providers, and OpenAI API outages).


### PR DESCRIPTION
### Motivation
- Capture operational best-practices for the `rest-express` deployment and translate package-level expectations into a repeatable runtime management baseline.
- Reduce release risk by documenting standard release workflow steps and production guardrails tied to the repository scripts (`npm run check`, `npm run build`, `npm run start`, `npm run db:push`).
- Provide clear service-boundary, dependency-governance, and incident/runbook guidance for high-risk providers used by 7ya.io.

### Description
- Added a new Section 11 to `docs/7ya-io-operating-plan.md` titled "7ya.io Node/Express Runtime Management Baseline" that targets the `rest-express` runtime.
- Documented a recommended release workflow that references repository scripts and the expected CI/pipeline behavior for build and deploy artifacts.
- Added `11.1 Service boundaries` guidance to isolate auth, realtime, and outbound-communications dependencies behind appropriate tiers and flags.
- Added `11.2 Dependency governance` and `11.3 Production controls` guidance to enforce version pinning, upgrade review, staged rollouts, health probes, and incident/runbook practices.

### Testing
- Ran `git diff --check` as a validation step and it completed without issues.
- This is a documentation-only change so no application unit/integration tests were required or run in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cafd50cbd48327992a0d81b873bbc5)