### PR TITLE
Make CLI input robust (EOF/empty) and add pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,15 @@ def main() -> None:
     # Supported options: Azure OpenAI, GitHub Models, OpenAI API.
     # See docs/setup.md for detailed configuration instructions.
 
-    user_name = input("Enter your name: ")
+    try:
+        user_name = input("Enter your name: ").strip()
+    except EOFError:
+        user_name = "Builder"
+        print("Enter your name: [auto] Builder")
+
+    if not user_name:
+        user_name = "Builder"
+
     print(get_greeting(user_name))
     print("\nNext steps:")
     print("  1. Read docs/setup.md to configure your environment.")


### PR DESCRIPTION
### Motivation
- Ensure the simple CLI in `src/main.py` behaves sensibly in non-interactive environments by providing a default name and avoiding crashes on EOF or empty input.
- Provide a basic `pytest` configuration so test discovery and execution are consistent across environments.

### Description
- Added `pytest.ini` to set `pythonpath = .` and `testpaths = tests` to configure pytest discovery.
- Updated `src/main.py` to `strip()` the result of `input()`, catch `EOFError`, and default the user name to `"Builder"` when input is empty or unavailable.
- When input is unavailable (`EOFError`) the code now prints a short auto-fill message and proceeds without raising an exception.
- No changes were made to `get_greeting`; it continues to return a personalised greeting string.

### Testing
- Added `pytest.ini` and ran `pytest -q` to validate test discovery, which completed successfully with no tests collected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3832d2a308327a2e8f71ea3d0a317)